### PR TITLE
feat(filters): add client-side search and filtering

### DIFF
--- a/src/components/FiltersBar.jsx
+++ b/src/components/FiltersBar.jsx
@@ -1,0 +1,110 @@
+import { SPOT_TYPES } from "../data/constants";
+import { formatTagLabel } from "../hooks/useSpotFilters";
+
+const PRICES = ["$", "$$", "$$$", "$$$$"];
+
+/**
+ * Reusable filter bar for spot listings.
+ *
+ * Props:
+ *  - search, onSearchChange        — search input
+ *  - activeType, onTypeChange       — category type filter
+ *  - activePrices, onPriceToggle    — price filter (multi-select)
+ *  - activeTags, onTagToggle        — tag chips (multi-select)
+ *  - availableTags                  — derived from data
+ *  - hasActiveFilters, onClear      — clear state
+ *  - resultCount                    — number of results
+ *  - compact                        — if true, hide category row (for HomePage)
+ */
+export default function FiltersBar({
+  search,
+  onSearchChange,
+  activeType,
+  onTypeChange,
+  activePrices,
+  onPriceToggle,
+  activeTags,
+  onTagToggle,
+  availableTags,
+  hasActiveFilters,
+  onClear,
+  resultCount,
+  compact = false,
+}) {
+  return (
+    <div className="filters-bar">
+      {/* Search */}
+      <div className="search-wrapper">
+        <input
+          value={search}
+          onChange={(e) => onSearchChange(e.target.value)}
+          placeholder="Search spots, tags, or wellness goals..."
+          className="search-input"
+          aria-label="Search spots"
+        />
+      </div>
+
+      {/* Category type tabs (hidden in compact mode) */}
+      {!compact && (
+        <div className="filter-row">
+          {SPOT_TYPES.map((t) => (
+            <button
+              key={t}
+              onClick={() => onTypeChange(t)}
+              className={`pill-btn pill-btn--dark${activeType === t ? " pill-btn--dark-active" : ""}`}
+            >
+              {t}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Price + Tag chips */}
+      <div className="filter-panel">
+        {/* Price row */}
+        <div className="filters-bar__section">
+          <span className="filter-panel-label">Price</span>
+          <div className="filters-bar__chips">
+            {PRICES.map((p) => (
+              <button
+                key={p}
+                onClick={() => onPriceToggle(p)}
+                className={`pill-btn${activePrices.includes(p) ? " pill-btn--active" : ""}`}
+              >
+                {p}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Tag chips */}
+        <div className="filters-bar__section">
+          <span className="filter-panel-label">Health Filters</span>
+          <div className="filters-bar__chips">
+            {availableTags.map((t) => (
+              <button
+                key={t}
+                onClick={() => onTagToggle(t)}
+                className={`pill-btn${activeTags.includes(t) ? " pill-btn--active" : ""}`}
+              >
+                {formatTagLabel(t)}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Meta row: result count + clear */}
+      <div className="filters-bar__meta">
+        <span className="filters-bar__count">
+          {resultCount} {resultCount === 1 ? "spot" : "spots"} found
+        </span>
+        {hasActiveFilters && (
+          <button onClick={onClear} className="filters-bar__clear">
+            Clear filters
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useSpotFilters.js
+++ b/src/hooks/useSpotFilters.js
@@ -1,0 +1,115 @@
+import { useState, useEffect, useMemo } from "react";
+
+/**
+ * Formats a kebab-case tag into a display label.
+ * "keto-friendly" → "Keto Friendly", "no-seed-oils" → "No Seed Oils"
+ */
+export function formatTagLabel(tag) {
+  return tag
+    .split("-")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+/**
+ * Reusable hook for filtering and searching spots.
+ *
+ * @param {Array} spots - array of spot objects
+ * @param {Object} options
+ * @param {string} options.sortBy - "trending" | "rating"
+ * @returns filter state, setters, filtered results
+ */
+export function useSpotFilters(spots, { sortBy = "trending" } = {}) {
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [activeType, setActiveType] = useState("All");
+  const [activePrices, setActivePrices] = useState([]);
+  const [activeTags, setActiveTags] = useState([]);
+
+  // Debounce search input (250ms)
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(search), 250);
+    return () => clearTimeout(timer);
+  }, [search]);
+
+  // Derive unique tags that actually exist in the data
+  const availableTags = useMemo(() => {
+    if (!spots) return [];
+    const tagSet = new Set();
+    spots.forEach((s) => s.tags.forEach((t) => tagSet.add(t)));
+    return [...tagSet].sort();
+  }, [spots]);
+
+  // Toggle helpers
+  const togglePrice = (p) =>
+    setActivePrices((prev) =>
+      prev.includes(p) ? prev.filter((x) => x !== p) : [...prev, p]
+    );
+
+  const toggleTag = (t) =>
+    setActiveTags((prev) =>
+      prev.includes(t) ? prev.filter((x) => x !== t) : [...prev, t]
+    );
+
+  // Core filtering: filters first, then search
+  const filteredSpots = useMemo(() => {
+    return (spots || [])
+      .filter((s) => {
+        // Type filter
+        if (activeType !== "All" && s.type !== activeType) return false;
+        // Price filter (OR within prices)
+        if (activePrices.length > 0 && !activePrices.includes(s.price))
+          return false;
+        // Tag filter (OR — match any selected tag)
+        if (
+          activeTags.length > 0 &&
+          !activeTags.some((tag) => s.tags.includes(tag))
+        )
+          return false;
+        // Search applies after filters (partial match on name, type, tags)
+        if (debouncedSearch) {
+          const q = debouncedSearch.toLowerCase();
+          const matchName = s.name.toLowerCase().includes(q);
+          const matchType = s.type.toLowerCase().includes(q);
+          const matchTags = s.tags.some((t) => t.toLowerCase().includes(q));
+          if (!matchName && !matchType && !matchTags) return false;
+        }
+        return true;
+      })
+      .sort((a, b) =>
+        sortBy === "trending"
+          ? b.trending - a.trending
+          : b.rating - a.rating
+      );
+  }, [spots, activeType, activePrices, activeTags, debouncedSearch, sortBy]);
+
+  const hasActiveFilters =
+    activeType !== "All" ||
+    activePrices.length > 0 ||
+    activeTags.length > 0 ||
+    search !== "";
+
+  const clearFilters = () => {
+    setSearch("");
+    setDebouncedSearch("");
+    setActiveType("All");
+    setActivePrices([]);
+    setActiveTags([]);
+  };
+
+  return {
+    filteredSpots,
+    search,
+    setSearch,
+    activeType,
+    setActiveType,
+    activePrices,
+    togglePrice,
+    activeTags,
+    toggleTag,
+    availableTags,
+    hasActiveFilters,
+    clearFilters,
+    resultCount: filteredSpots.length,
+  };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -929,6 +929,66 @@ button {
   border-bottom: 1px solid var(--gray-100);
 }
 
+/* ─── Filters Bar ──────────────────────────────────────────── */
+.filters-bar {
+  margin-bottom: 24px;
+}
+
+.filters-bar__section {
+  margin-bottom: 12px;
+}
+
+.filters-bar__section:last-child {
+  margin-bottom: 0;
+}
+
+.filters-bar__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+@media (max-width: 768px) {
+  .filters-bar__chips {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    scrollbar-width: none;
+    padding-bottom: 4px;
+  }
+
+  .filters-bar__chips::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+.filters-bar__meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.filters-bar__count {
+  color: var(--gray-500);
+  font-size: 13px;
+}
+
+.filters-bar__clear {
+  background: none;
+  border: none;
+  color: var(--green-600);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 6px;
+  transition: background 0.15s;
+}
+
+.filters-bar__clear:hover {
+  background: var(--green-50);
+}
+
 /* ─── States ────────────────────────────────────────────────── */
 .loading-state {
   text-align: center;

--- a/src/pages/ExplorePage.jsx
+++ b/src/pages/ExplorePage.jsx
@@ -1,60 +1,53 @@
 import { useState } from "react";
 import { useApi } from "../hooks/useApi";
-import { FILTERS, SPOT_TYPES } from "../data/constants";
+import { useSpotFilters } from "../hooks/useSpotFilters";
+import FiltersBar from "../components/FiltersBar";
 import SpotCard from "../components/SpotCard";
 import SpotModal from "../components/SpotModal";
 
 export default function ExplorePage() {
-  const [search, setSearch] = useState("");
-  const [activeFilters, setActiveFilters] = useState([]);
-  const [activeType, setActiveType] = useState("All");
   const [sortBy, setSortBy] = useState("trending");
   const [showMap, setShowMap] = useState(false);
   const [selectedSpot, setSelectedSpot] = useState(null);
 
   const { data: spots, loading, error } = useApi("/spots");
 
-  const toggleFilter = (f) =>
-    setActiveFilters((prev) =>
-      prev.includes(f) ? prev.filter((x) => x !== f) : [...prev, f]
-    );
-
-  const filtered = (spots || [])
-    .filter((s) => {
-      const matchSearch =
-        !search ||
-        s.name.toLowerCase().includes(search.toLowerCase()) ||
-        s.tags.some((t) => t.includes(search.toLowerCase()));
-      const matchType = activeType === "All" || s.type === activeType;
-      const matchFilters =
-        activeFilters.length === 0 ||
-        activeFilters.some((f) =>
-          s.tags.some(
-            (t) => t.toLowerCase() === f.toLowerCase().replace(" ", "-")
-          )
-        );
-      return matchSearch && matchType && matchFilters;
-    })
-    .sort((a, b) =>
-      sortBy === "trending" ? b.trending - a.trending : b.rating - a.rating
-    );
+  const {
+    filteredSpots,
+    search,
+    setSearch,
+    activeType,
+    setActiveType,
+    activePrices,
+    togglePrice,
+    activeTags,
+    toggleTag,
+    availableTags,
+    hasActiveFilters,
+    clearFilters,
+    resultCount,
+  } = useSpotFilters(spots, { sortBy });
 
   return (
     <div>
       <h2 className="page-title">Explore Near You</h2>
 
-      {/* Search */}
-      <div className="search-wrapper">
-        <input
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          placeholder="Search spots, tags, or wellness goals..."
-          className="search-input"
-          aria-label="Search spots"
-        />
-      </div>
+      <FiltersBar
+        search={search}
+        onSearchChange={setSearch}
+        activeType={activeType}
+        onTypeChange={setActiveType}
+        activePrices={activePrices}
+        onPriceToggle={togglePrice}
+        activeTags={activeTags}
+        onTagToggle={toggleTag}
+        availableTags={availableTags}
+        hasActiveFilters={hasActiveFilters}
+        onClear={clearFilters}
+        resultCount={resultCount}
+      />
 
-      {/* Controls */}
+      {/* Sort + Map controls */}
       <div
         style={{
           display: "flex",
@@ -79,38 +72,6 @@ export default function ExplorePage() {
         >
           {showMap ? "List" : "Map"}
         </button>
-        <div style={{ marginLeft: "auto", color: "#6B7280", fontSize: 13 }}>
-          {filtered.length} spots found
-        </div>
-      </div>
-
-      {/* Spot Type Tabs */}
-      <div className="filter-row">
-        {SPOT_TYPES.map((t) => (
-          <button
-            key={t}
-            onClick={() => setActiveType(t)}
-            className={`pill-btn pill-btn--dark${activeType === t ? " pill-btn--dark-active" : ""}`}
-          >
-            {t}
-          </button>
-        ))}
-      </div>
-
-      {/* Deep Filters */}
-      <div className="filter-panel">
-        <div className="filter-panel-label">Filter by Preference</div>
-        <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
-          {FILTERS.filter((f) => f !== "All").map((f) => (
-            <button
-              key={f}
-              onClick={() => toggleFilter(f)}
-              className={`pill-btn${activeFilters.includes(f) ? " pill-btn--active" : ""}`}
-            >
-              {f}
-            </button>
-          ))}
-        </div>
       </div>
 
       {/* Map Placeholder */}
@@ -128,10 +89,10 @@ export default function ExplorePage() {
             Interactive Map
           </div>
           <div style={{ color: "#16A34A", fontSize: 13 }}>
-            {filtered.length} healthy spots plotted near Birmingham, AL
+            {resultCount} healthy spots plotted near Birmingham, AL
           </div>
           <div style={{ display: "flex", gap: 10, marginTop: 16, flexWrap: "wrap", justifyContent: "center" }}>
-            {filtered.slice(0, 4).map((s) => (
+            {filteredSpots.slice(0, 4).map((s) => (
               <button
                 key={s.id}
                 onClick={() => setSelectedSpot(s)}
@@ -152,17 +113,17 @@ export default function ExplorePage() {
         <div className="error-state">
           <p>Failed to load spots. Please try again later.</p>
         </div>
-      ) : filtered.length === 0 ? (
+      ) : filteredSpots.length === 0 ? (
         <div className="empty-state">
           <div style={{ fontSize: 40, marginBottom: 12 }}>&#x1F50D;</div>
-          <div style={{ fontSize: 16, fontWeight: 600 }}>No spots found</div>
+          <div style={{ fontSize: 16, fontWeight: 600 }}>No results</div>
           <div style={{ fontSize: 13, marginTop: 4 }}>
-            Try adjusting your filters
+            Try clearing filters.
           </div>
         </div>
       ) : (
         <div className="grid grid--4">
-          {filtered.map((s) => (
+          {filteredSpots.map((s) => (
             <SpotCard key={s.id} spot={s} onClick={setSelectedSpot} />
           ))}
         </div>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,25 +1,30 @@
 import { useState } from "react";
 import { useApi } from "../hooks/useApi";
-import { FILTERS } from "../data/constants";
+import { useSpotFilters } from "../hooks/useSpotFilters";
+import FiltersBar from "../components/FiltersBar";
 import SpotCard from "../components/SpotCard";
 import SpotModal from "../components/SpotModal";
 
 export default function HomePage() {
-  const [activeFilter, setActiveFilter] = useState("All");
   const [selectedSpot, setSelectedSpot] = useState(null);
   const { data: spots, loading: spotsLoading, error: spotsError } = useApi("/spots");
   const { data: trends, loading: trendsLoading } = useApi("/trends");
 
-  const filtered =
-    !spots
-      ? []
-      : activeFilter === "All"
-        ? spots
-        : spots.filter((s) =>
-            s.tags.some(
-              (t) => t.toLowerCase() === activeFilter.toLowerCase().replace(" ", "-")
-            )
-          );
+  const {
+    filteredSpots,
+    search,
+    setSearch,
+    activeType,
+    setActiveType,
+    activePrices,
+    togglePrice,
+    activeTags,
+    toggleTag,
+    availableTags,
+    hasActiveFilters,
+    clearFilters,
+    resultCount,
+  } = useSpotFilters(spots);
 
   const hotTrends = trends ? trends.filter((t) => t.hot).slice(0, 3) : [];
 
@@ -48,19 +53,6 @@ export default function HomePage() {
           </div>
         </div>
       </section>
-
-      {/* Quick Filters */}
-      <div className="filter-row">
-        {FILTERS.slice(0, 10).map((f) => (
-          <button
-            key={f}
-            onClick={() => setActiveFilter(f)}
-            className={`pill-btn${activeFilter === f ? " pill-btn--active" : ""}`}
-          >
-            {f}
-          </button>
-        ))}
-      </div>
 
       {/* What's Hot */}
       <section style={{ marginBottom: 32 }}>
@@ -159,23 +151,40 @@ export default function HomePage() {
             </p>
           </div>
         </div>
+
+        <FiltersBar
+          search={search}
+          onSearchChange={setSearch}
+          activeType={activeType}
+          onTypeChange={setActiveType}
+          activePrices={activePrices}
+          onPriceToggle={togglePrice}
+          activeTags={activeTags}
+          onTagToggle={toggleTag}
+          availableTags={availableTags}
+          hasActiveFilters={hasActiveFilters}
+          onClear={clearFilters}
+          resultCount={resultCount}
+          compact
+        />
+
         {spotsLoading ? (
           <div className="loading-state">Loading spots...</div>
         ) : spotsError ? (
           <div className="error-state">
             <p>Failed to load spots. Please try again later.</p>
           </div>
-        ) : filtered.length === 0 ? (
+        ) : filteredSpots.length === 0 ? (
           <div className="empty-state">
             <div style={{ fontSize: 40, marginBottom: 12 }}>&#x1F50D;</div>
-            <div style={{ fontSize: 16, fontWeight: 600 }}>No spots found</div>
+            <div style={{ fontSize: 16, fontWeight: 600 }}>No results</div>
             <div style={{ fontSize: 13, marginTop: 4 }}>
-              Try adjusting your filters
+              Try clearing filters.
             </div>
           </div>
         ) : (
           <div className="grid grid--4">
-            {filtered.map((s) => (
+            {filteredSpots.map((s) => (
               <SpotCard key={s.id} spot={s} onClick={setSelectedSpot} />
             ))}
           </div>


### PR DESCRIPTION
- Create reusable useSpotFilters hook with debounced search (250ms), category type, price, and tag filters with clear-all support
- Create FiltersBar component with search input, category tabs, price chips, and health tag chips (dynamically derived from data)
- Integrate into HomePage (compact mode) and ExplorePage (full mode)
- Add responsive CSS: horizontal scroll chips on mobile
- Empty state shows "No results. Try clearing filters."

https://claude.ai/code/session_011pM84MJ7AbvrbXTrmniF9J